### PR TITLE
fix: requirements notations for newer setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ setup_requires =
     setuptools>=38.6.0
     wheel>=0.31.0
     cython>=0.29.0
-    setuptools-scm>=6.*
+    setuptools-scm>=6
 install_requires =
 tests_require =
     pytest
@@ -34,12 +34,12 @@ package_dir =
 [options.extras_require]
 dev =
     black>=23.3
-    flake8>=3.9.*
-    jinja2>=3.*
+    flake8>=3.9
+    jinja2>=3
     mypy>=0.910
-    pytest>=6.2.*
-    sphinx>=4.*
-    sphinx-rtd-theme>=0.5.*
+    pytest>=6.2
+    sphinx>=4
+    sphinx-rtd-theme>=0.5
 
 [options.package_data]
 * =


### PR DESCRIPTION
## Summary

* Wildcards seem to have been no longer valid.