### PR TITLE
fix: remove redundant artifacts in wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ files = "src/"
 [tool.cibuildwheel]
 build = ["cp310-*", "cp311-*",  "cp312-*", "cp313-*"]
 # skip = "pp*"
+before_build = "find /project -iname '*.so' | xargs rm -f"
 
 [tool.cibuildwheel.macos]
 archs = ["universal2"]


### PR DESCRIPTION
## Summary

* Because the docker volume is reused over multiple builds, build artifacts may remain and accumulate in the build directory, hence the resulting wheels contain redundant artifacts (*.so).